### PR TITLE
Implemented compatibility with log4j 1.2.14

### DIFF
--- a/src/main/java/org/log4mongo/LoggingEventBsonifierImpl.java
+++ b/src/main/java/org/log4mongo/LoggingEventBsonifierImpl.java
@@ -68,7 +68,7 @@ public class LoggingEventBsonifierImpl implements LoggingEventBsonifier {
 	if (loggingEvent != null) {
 	    result = new BasicDBObject();
 
-	    result.put("timestamp", new Date(loggingEvent.getTimeStamp()));
+	    result.put("timestamp", new Date(loggingEvent.timeStamp));
 	    nullSafePut(result, "level", loggingEvent.getLevel().toString());
 	    nullSafePut(result, "thread", loggingEvent.getThreadName());
 	    nullSafePut(result, "message", loggingEvent.getMessage());


### PR DESCRIPTION
The current implementation uses getTimeStamp() method not available
in older version of log4j. To use it with 1.2.14 for example one needs
to switch to field access instead of method access to get the timestamp
information
