### PR TITLE
Refactored the activateOptions to pick up the instances of Db and Mongo object, if we are creating appenders dynamically in log4j appenders.

### DIFF
--- a/src/main/java/org/log4mongo/LoggingEventBsonifier.java
+++ b/src/main/java/org/log4mongo/LoggingEventBsonifier.java
@@ -25,6 +25,6 @@ import com.mongodb.DBObject;
  * Interface implemented by classes that create a BSON representation of a Log4J
  * LoggingEvent. LoggingEventBsonifierImpl is the default implementation.
  */
-public interface LoggingEventBsonifier {
-    DBObject bsonify(LoggingEvent loggingEvent);
+public interface LoggingEventBsonifier extends MongoDBInternalConstants {
+	DBObject bsonify(LoggingEvent loggingEvent);
 }

--- a/src/main/java/org/log4mongo/LoggingEventBsonifierImpl.java
+++ b/src/main/java/org/log4mongo/LoggingEventBsonifierImpl.java
@@ -35,283 +35,280 @@ import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
 
 /**
- * Default implementation class for creating a BSON representation of a Log4J LoggingEvent.
+ * Default implementation class for creating a BSON representation of a Log4J
+ * LoggingEvent.
  */
 public class LoggingEventBsonifierImpl implements LoggingEventBsonifier {
 
-    // Main log event elements
-    private static final String KEY_TIMESTAMP = "timestamp";
-    private static final String KEY_LEVEL = "level";
-    private static final String KEY_THREAD = "thread";
-    private static final String KEY_MESSAGE = "message";
-    private static final String KEY_LOGGER_NAME = "loggerName";
-    // Source code location
-    private static final String KEY_FILE_NAME = "fileName";
-    private static final String KEY_METHOD = "method";
-    private static final String KEY_LINE_NUMBER = "lineNumber";
-    private static final String KEY_CLASS = "class";
-    // Class info
-    private static final String KEY_FQCN = "fullyQualifiedClassName";
-    private static final String KEY_PACKAGE = "package";
-    private static final String KEY_CLASS_NAME = "className";
-    // Exceptions
-    private static final String KEY_THROWABLES = "throwables";
-    private static final String KEY_EXCEPTION_MESSAGE = "message";
-    private static final String KEY_STACK_TRACE = "stackTrace";
-    // Host and Process Info
-    private static final String KEY_HOST = "host";
-    private static final String KEY_PROCESS = "process";
-    private static final String KEY_HOSTNAME = "name";
-    private static final String KEY_IP = "ip";
-    // MDC Properties
-    private static final String KEY_MDC_PROPERTIES = "properties";
+	private DBObject hostInfo = new BasicDBObject();
 
-    private DBObject hostInfo = new BasicDBObject();
+	public LoggingEventBsonifierImpl() {
+		setupNetworkInfo();
+	}
 
-    public LoggingEventBsonifierImpl() {
-        setupNetworkInfo();
-    }
+	private void setupNetworkInfo() {
+		hostInfo.put(KEY_PROCESS, ManagementFactory.getRuntimeMXBean()
+				.getName());
+		try {
+			hostInfo.put(KEY_HOSTNAME, InetAddress.getLocalHost().getHostName());
+			hostInfo.put(KEY_IP, InetAddress.getLocalHost().getHostAddress());
+		} catch (UnknownHostException e) {
+			LogLog.warn(e.getMessage());
+		}
+	}
 
-    private void setupNetworkInfo() {
-        hostInfo.put(KEY_PROCESS, ManagementFactory.getRuntimeMXBean().getName());
-        try {
-            hostInfo.put(KEY_HOSTNAME, InetAddress.getLocalHost().getHostName());
-            hostInfo.put(KEY_IP, InetAddress.getLocalHost().getHostAddress());
-        } catch (UnknownHostException e) {
-            LogLog.warn(e.getMessage());
-        }
-    }
+	/**
+	 * BSONifies a single Log4J LoggingEvent object.
+	 * 
+	 * @param loggingEvent
+	 *            The LoggingEvent object to BSONify <i>(may be null)</i>.
+	 * @return The BSONified equivalent of the LoggingEvent object <i>(may be
+	 *         null)</i>.
+	 */
+	public DBObject bsonify(final LoggingEvent loggingEvent) {
+		DBObject result = null;
 
-    /**
-     * BSONifies a single Log4J LoggingEvent object.
-     * 
-     * @param loggingEvent
-     *            The LoggingEvent object to BSONify <i>(may be null)</i>.
-     * @return The BSONified equivalent of the LoggingEvent object <i>(may be null)</i>.
-     */
-    public DBObject bsonify(final LoggingEvent loggingEvent) {
-        DBObject result = null;
+		if (loggingEvent != null) {
+			result = new BasicDBObject();
 
-        if (loggingEvent != null) {
-            result = new BasicDBObject();
+			result.put(KEY_TIMESTAMP, new Date(loggingEvent.getTimeStamp()));
+			nullSafePut(result, KEY_LEVEL, loggingEvent.getLevel().toString());
+			nullSafePut(result, KEY_THREAD, loggingEvent.getThreadName());
+			nullSafePut(result, KEY_MESSAGE, loggingEvent.getMessage());
+			nullSafePut(result, KEY_LOGGER_NAME,
+					bsonifyClassName(loggingEvent.getLoggerName()));
 
-            result.put(KEY_TIMESTAMP, new Date(loggingEvent.getTimeStamp()));
-            nullSafePut(result, KEY_LEVEL, loggingEvent.getLevel().toString());
-            nullSafePut(result, KEY_THREAD, loggingEvent.getThreadName());
-            nullSafePut(result, KEY_MESSAGE, loggingEvent.getMessage());
-            nullSafePut(result, KEY_LOGGER_NAME, bsonifyClassName(loggingEvent.getLoggerName()));
+			addMDCInformation(result, loggingEvent.getProperties());
+			addLocationInformation(result,
+					loggingEvent.getLocationInformation());
+			addThrowableInformation(result,
+					loggingEvent.getThrowableInformation());
+			addHostnameInformation(result);
+		}
 
-            addMDCInformation(result, loggingEvent.getProperties());
-            addLocationInformation(result, loggingEvent.getLocationInformation());
-            addThrowableInformation(result, loggingEvent.getThrowableInformation());
-            addHostnameInformation(result);
-        }
+		return (result);
+	}
 
-        return (result);
-    }
+	/**
+	 * Adds MDC Properties to the DBObject.
+	 * 
+	 * @param bson
+	 *            The root DBObject
+	 * @param props
+	 *            MDC Properties to be logged
+	 */
+	protected void addMDCInformation(DBObject bson,
+			final Map<Object, Object> props) {
+		if (props != null && props.size() > 0) {
 
-    /**
-     * Adds MDC Properties to the DBObject.
-     * 
-     * @param bson
-     *            The root DBObject
-     * @param props
-     *            MDC Properties to be logged
-     */
-    protected void addMDCInformation(DBObject bson, final Map<Object, Object> props) {
-        if (props != null && props.size() > 0) {
+			BasicDBObject mdcProperties = new BasicDBObject();
 
-            BasicDBObject mdcProperties = new BasicDBObject();
+			// Copy MDC properties into document
+			for (Map.Entry<Object, Object> entry : props.entrySet()) {
+				nullSafePut(mdcProperties, entry.getKey().toString(), entry
+						.getValue().toString());
+			}
+			bson.put(KEY_MDC_PROPERTIES, mdcProperties);
+		}
+	}
 
-            // Copy MDC properties into document
-            for (Map.Entry<Object, Object> entry : props.entrySet()) {
-                nullSafePut(mdcProperties, entry.getKey().toString(), entry.getValue().toString());
-            }
-            bson.put(KEY_MDC_PROPERTIES, mdcProperties);
-        }
-    }
+	/**
+	 * Adds the LocationInfo object to an existing BSON object.
+	 * 
+	 * @param bson
+	 *            The BSON object to add the location info to <i>(must not be
+	 *            null)</i>.
+	 * @param locationInfo
+	 *            The LocationInfo object to add to the BSON object <i>(may be
+	 *            null)</i>.
+	 */
+	protected void addLocationInformation(DBObject bson,
+			final LocationInfo locationInfo) {
+		if (locationInfo != null) {
+			nullSafePut(bson, KEY_FILE_NAME, locationInfo.getFileName());
+			nullSafePut(bson, KEY_METHOD, locationInfo.getMethodName());
+			nullSafePut(bson, KEY_LINE_NUMBER, locationInfo.getLineNumber());
+			nullSafePut(bson, KEY_CLASS,
+					bsonifyClassName(locationInfo.getClassName()));
+		}
+	}
 
-    /**
-     * Adds the LocationInfo object to an existing BSON object.
-     * 
-     * @param bson
-     *            The BSON object to add the location info to <i>(must not be null)</i>.
-     * @param locationInfo
-     *            The LocationInfo object to add to the BSON object <i>(may be null)</i>.
-     */
-    protected void addLocationInformation(DBObject bson, final LocationInfo locationInfo) {
-        if (locationInfo != null) {
-            nullSafePut(bson, KEY_FILE_NAME, locationInfo.getFileName());
-            nullSafePut(bson, KEY_METHOD, locationInfo.getMethodName());
-            nullSafePut(bson, KEY_LINE_NUMBER, locationInfo.getLineNumber());
-            nullSafePut(bson, KEY_CLASS, bsonifyClassName(locationInfo.getClassName()));
-        }
-    }
+	/**
+	 * Adds the ThrowableInformation object to an existing BSON object.
+	 * 
+	 * @param bson
+	 *            The BSON object to add the throwable info to <i>(must not be
+	 *            null)</i>.
+	 * @param throwableInfo
+	 *            The ThrowableInformation object to add to the BSON object
+	 *            <i>(may be null)</i>.
+	 */
+	@SuppressWarnings(value = "unchecked")
+	protected void addThrowableInformation(DBObject bson,
+			final ThrowableInformation throwableInfo) {
+		if (throwableInfo != null) {
+			Throwable currentThrowable = throwableInfo.getThrowable();
+			List throwables = new BasicDBList();
 
-    /**
-     * Adds the ThrowableInformation object to an existing BSON object.
-     * 
-     * @param bson
-     *            The BSON object to add the throwable info to <i>(must not be null)</i>.
-     * @param throwableInfo
-     *            The ThrowableInformation object to add to the BSON object <i>(may be null)</i>.
-     */
-    @SuppressWarnings(value = "unchecked")
-    protected void addThrowableInformation(DBObject bson, final ThrowableInformation throwableInfo) {
-        if (throwableInfo != null) {
-            Throwable currentThrowable = throwableInfo.getThrowable();
-            List throwables = new BasicDBList();
+			while (currentThrowable != null) {
+				DBObject throwableBson = bsonifyThrowable(currentThrowable);
 
-            while (currentThrowable != null) {
-                DBObject throwableBson = bsonifyThrowable(currentThrowable);
+				if (throwableBson != null) {
+					throwables.add(throwableBson);
+				}
 
-                if (throwableBson != null) {
-                    throwables.add(throwableBson);
-                }
+				currentThrowable = currentThrowable.getCause();
+			}
 
-                currentThrowable = currentThrowable.getCause();
-            }
+			if (throwables.size() > 0) {
+				bson.put(KEY_THROWABLES, throwables);
+			}
+		}
+	}
 
-            if (throwables.size() > 0) {
-                bson.put(KEY_THROWABLES, throwables);
-            }
-        }
-    }
+	/**
+	 * Adds the current process's host name, VM name and IP address
+	 * 
+	 * @param bson
+	 *            A BSON object containing host name, VM name and IP address
+	 */
+	protected void addHostnameInformation(DBObject bson) {
+		nullSafePut(bson, KEY_HOST, hostInfo);
+	}
 
-    /**
-     * Adds the current process's host name, VM name and IP address
-     * 
-     * @param bson
-     *            A BSON object containing host name, VM name and IP address
-     */
-    protected void addHostnameInformation(DBObject bson) {
-        nullSafePut(bson, KEY_HOST, hostInfo);
-    }
+	/**
+	 * BSONifies the given Throwable.
+	 * 
+	 * @param throwable
+	 *            The throwable object to BSONify <i>(may be null)</i>.
+	 * @return The BSONified equivalent of the Throwable object <i>(may be
+	 *         null)</i>.
+	 */
+	protected DBObject bsonifyThrowable(final Throwable throwable) {
+		DBObject result = null;
 
-    /**
-     * BSONifies the given Throwable.
-     * 
-     * @param throwable
-     *            The throwable object to BSONify <i>(may be null)</i>.
-     * @return The BSONified equivalent of the Throwable object <i>(may be null)</i>.
-     */
-    protected DBObject bsonifyThrowable(final Throwable throwable) {
-        DBObject result = null;
+		if (throwable != null) {
+			result = new BasicDBObject();
 
-        if (throwable != null) {
-            result = new BasicDBObject();
+			nullSafePut(result, KEY_EXCEPTION_MESSAGE, throwable.getMessage());
+			nullSafePut(result, KEY_STACK_TRACE,
+					bsonifyStackTrace(throwable.getStackTrace()));
+		}
 
-            nullSafePut(result, KEY_EXCEPTION_MESSAGE, throwable.getMessage());
-            nullSafePut(result, KEY_STACK_TRACE, bsonifyStackTrace(throwable.getStackTrace()));
-        }
+		return (result);
+	}
 
-        return (result);
-    }
+	/**
+	 * BSONifies the given stack trace.
+	 * 
+	 * @param stackTrace
+	 *            The stack trace object to BSONify <i>(may be null)</i>.
+	 * @return The BSONified equivalent of the stack trace object <i>(may be
+	 *         null)</i>.
+	 */
+	protected DBObject bsonifyStackTrace(final StackTraceElement[] stackTrace) {
+		BasicDBList result = null;
 
-    /**
-     * BSONifies the given stack trace.
-     * 
-     * @param stackTrace
-     *            The stack trace object to BSONify <i>(may be null)</i>.
-     * @return The BSONified equivalent of the stack trace object <i>(may be null)</i>.
-     */
-    protected DBObject bsonifyStackTrace(final StackTraceElement[] stackTrace) {
-        BasicDBList result = null;
+		if (stackTrace != null && stackTrace.length > 0) {
+			result = new BasicDBList();
 
-        if (stackTrace != null && stackTrace.length > 0) {
-            result = new BasicDBList();
+			for (StackTraceElement element : stackTrace) {
+				DBObject bson = bsonifyStackTraceElement(element);
 
-            for (StackTraceElement element : stackTrace) {
-                DBObject bson = bsonifyStackTraceElement(element);
+				if (bson != null) {
+					result.add(bson);
+				}
+			}
+		}
 
-                if (bson != null) {
-                    result.add(bson);
-                }
-            }
-        }
+		return (result);
+	}
 
-        return (result);
-    }
+	/**
+	 * BSONifies the given stack trace element.
+	 * 
+	 * @param element
+	 *            The stack trace element object to BSONify <i>(may be
+	 *            null)</i>.
+	 * @return The BSONified equivalent of the stack trace element object
+	 *         <i>(may be null)</i>.
+	 */
+	protected DBObject bsonifyStackTraceElement(final StackTraceElement element) {
+		DBObject result = null;
 
-    /**
-     * BSONifies the given stack trace element.
-     * 
-     * @param element
-     *            The stack trace element object to BSONify <i>(may be null)</i>.
-     * @return The BSONified equivalent of the stack trace element object <i>(may be null)</i>.
-     */
-    protected DBObject bsonifyStackTraceElement(final StackTraceElement element) {
-        DBObject result = null;
+		if (element != null) {
+			result = new BasicDBObject();
 
-        if (element != null) {
-            result = new BasicDBObject();
+			nullSafePut(result, KEY_FILE_NAME, element.getFileName());
+			nullSafePut(result, KEY_METHOD, element.getMethodName());
+			nullSafePut(result, KEY_LINE_NUMBER, element.getLineNumber());
+			nullSafePut(result, KEY_CLASS,
+					bsonifyClassName(element.getClassName()));
+		}
 
-            nullSafePut(result, KEY_FILE_NAME, element.getFileName());
-            nullSafePut(result, KEY_METHOD, element.getMethodName());
-            nullSafePut(result, KEY_LINE_NUMBER, element.getLineNumber());
-            nullSafePut(result, KEY_CLASS, bsonifyClassName(element.getClassName()));
-        }
+		return (result);
+	}
 
-        return (result);
-    }
+	/**
+	 * BSONifies the given class name.
+	 * 
+	 * @param className
+	 *            The class name to BSONify <i>(may be null)</i>.
+	 * @return The BSONified equivalent of the class name <i>(may be null)</i>.
+	 */
+	@SuppressWarnings(value = "unchecked")
+	protected DBObject bsonifyClassName(final String className) {
+		DBObject result = null;
 
-    /**
-     * BSONifies the given class name.
-     * 
-     * @param className
-     *            The class name to BSONify <i>(may be null)</i>.
-     * @return The BSONified equivalent of the class name <i>(may be null)</i>.
-     */
-    @SuppressWarnings(value = "unchecked")
-    protected DBObject bsonifyClassName(final String className) {
-        DBObject result = null;
+		if (className != null && className.trim().length() > 0) {
+			result = new BasicDBObject();
 
-        if (className != null && className.trim().length() > 0) {
-            result = new BasicDBObject();
+			result.put(KEY_FQCN, className);
 
-            result.put(KEY_FQCN, className);
+			List packageComponents = new BasicDBList();
+			String[] packageAndClassName = className.split("\\.");
 
-            List packageComponents = new BasicDBList();
-            String[] packageAndClassName = className.split("\\.");
+			packageComponents.addAll(Arrays.asList(packageAndClassName));
+			// Requires Java 6
+			// packageComponents.addAll(Arrays.asList(Arrays.copyOf(packageAndClassName,
+			// packageAndClassName.length - 1)));
 
-            packageComponents.addAll(Arrays.asList(packageAndClassName));
-            // Requires Java 6
-            // packageComponents.addAll(Arrays.asList(Arrays.copyOf(packageAndClassName,
-            // packageAndClassName.length - 1)));
+			if (packageComponents.size() > 0) {
+				result.put(KEY_PACKAGE, packageComponents);
+			}
 
-            if (packageComponents.size() > 0) {
-                result.put(KEY_PACKAGE, packageComponents);
-            }
+			result.put(KEY_CLASS_NAME,
+					packageAndClassName[packageAndClassName.length - 1]);
+		}
 
-            result.put(KEY_CLASS_NAME, packageAndClassName[packageAndClassName.length - 1]);
-        }
+		return (result);
+	}
 
-        return (result);
-    }
+	/**
+	 * Adds the given value to the given key, except if it's null (in which case
+	 * this method does nothing).
+	 * 
+	 * @param bson
+	 *            The BSON object to add the key/value to <i>(must not be
+	 *            null)</i>.
+	 * @param key
+	 *            The key of the object <i>(must not be null)</i>.
+	 * @param value
+	 *            The value of the object <i>(may be null)</i>.
+	 */
+	protected void nullSafePut(DBObject bson, final String key,
+			final Object value) {
+		if (value != null) {
+			if (value instanceof String) {
+				String stringValue = (String) value;
 
-    /**
-     * Adds the given value to the given key, except if it's null (in which case this method does
-     * nothing).
-     * 
-     * @param bson
-     *            The BSON object to add the key/value to <i>(must not be null)</i>.
-     * @param key
-     *            The key of the object <i>(must not be null)</i>.
-     * @param value
-     *            The value of the object <i>(may be null)</i>.
-     */
-    protected void nullSafePut(DBObject bson, final String key, final Object value) {
-        if (value != null) {
-            if (value instanceof String) {
-                String stringValue = (String) value;
-
-                if (stringValue.trim().length() > 0) {
-                    bson.put(key, stringValue);
-                }
-            } else {
-                bson.put(key, value);
-            }
-        }
-    }
+				if (stringValue.trim().length() > 0) {
+					bson.put(key, stringValue);
+				}
+			} else {
+				bson.put(key, value);
+			}
+		}
+	}
 
 }

--- a/src/main/java/org/log4mongo/MongoDBInternalConstants.java
+++ b/src/main/java/org/log4mongo/MongoDBInternalConstants.java
@@ -1,0 +1,61 @@
+package org.log4mongo;
+
+/*
+ * Interface Class Providing all the constants required by log4Mongo. 
+ * It includes the constants providing the header information.
+ */
+public interface MongoDBInternalConstants {
+	/*
+	 * Default Mongo DB Hostname. The default hostname is 'localhost' if you are
+	 * running in the local environment. Otherwise, it is preferable to use an
+	 * IP Address. e.g. : https://127.0.0.1/ <br />Do not include the port
+	 * number in the hostname
+	 */
+	final static String DEFAULT_MONGO_DB_HOSTNAME = "localhost";
+	/*
+	 * Default Port Number for Mongo. Mongo runs on 27017 by default when
+	 * deployed.
+	 */
+	final static String DEFAULT_MONGO_DB_PORT = "27017";
+	/*
+	 * The database name where the collection is to be used . If the database
+	 * doesnt exist, it will be created automatically.
+	 */
+	final static String DEFAULT_MONGO_DB_DATABASE_NAME = "log4mongo";
+	/*
+	 * The Collection name used to store the documents. If the collection doesnt
+	 * exist, it will be created automatically.
+	 */
+	final static String DEFAULT_MONGO_DB_COLLECTION_NAME = "logevents";
+
+	/*
+	 * The DBObject element names.
+	 */
+	// Main log event elements
+	static final String KEY_TIMESTAMP = "timestamp";
+	static final String KEY_LEVEL = "level";
+	static final String KEY_THREAD = "thread";
+	static final String KEY_MESSAGE = "message";
+	static final String KEY_LOGGER_NAME = "loggerName";
+	// Source code location
+	static final String KEY_FILE_NAME = "fileName";
+	static final String KEY_METHOD = "method";
+	static final String KEY_LINE_NUMBER = "lineNumber";
+	static final String KEY_CLASS = "class";
+	// Class info
+	static final String KEY_FQCN = "fullyQualifiedClassName";
+	static final String KEY_PACKAGE = "package";
+	static final String KEY_CLASS_NAME = "className";
+	// Exceptions
+	static final String KEY_THROWABLES = "throwables";
+	static final String KEY_EXCEPTION_MESSAGE = "message";
+	static final String KEY_STACK_TRACE = "stackTrace";
+	// Host and Process Info
+	static final String KEY_HOST = "host";
+	static final String KEY_PROCESS = "process";
+	static final String KEY_HOSTNAME = "name";
+	static final String KEY_IP = "ip";
+	// MDC Properties
+	static final String KEY_MDC_PROPERTIES = "properties";
+
+}

--- a/src/main/java/org/log4mongo/MongoDbAppender.java
+++ b/src/main/java/org/log4mongo/MongoDbAppender.java
@@ -31,88 +31,89 @@ import com.mongodb.MongoException;
 import com.mongodb.ServerAddress;
 
 /**
- * Log4J Appender that writes log events into a MongoDB document oriented database. Log events are
- * fully parsed and stored as structured records in MongoDB (this appender does not require, nor use
- * a Log4J layout).
+ * Log4J Appender that writes log events into a MongoDB document oriented
+ * database. Log events are fully parsed and stored as structured records in
+ * MongoDB (this appender does not require, nor use a Log4J layout).
  * 
- * The appender does <u>not</u> create any indexes on the data that's stored - it is assumed that if
- * query performance is required, those would be created externally (e.g., in the MongoDB shell or
- * other external application).
+ * The appender does <u>not</u> create any indexes on the data that's stored -
+ * it is assumed that if query performance is required, those would be created
+ * externally (e.g., in the MongoDB shell or other external application).
  * 
  * @author Peter Monks (pmonks@gmail.com)
- * @see <a href="http://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/Appender.html">Log4J
+ * @see <a
+ *      href="http://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/Appender.html">Log4J
  *      Appender Interface</a>
  * @see <a href="http://www.mongodb.org/">MongoDB</a>
  */
-public class MongoDbAppender extends BsonAppender {
-    private final static String DEFAULT_MONGO_DB_HOSTNAME = "localhost";
-    private final static String DEFAULT_MONGO_DB_PORT = "27017";
-    private final static String DEFAULT_MONGO_DB_DATABASE_NAME = "log4mongo";
-    private final static String DEFAULT_MONGO_DB_COLLECTION_NAME = "logevents";
+public class MongoDbAppender extends BsonAppender implements
+		MongoDBInternalConstants {
 
-    private String hostname = DEFAULT_MONGO_DB_HOSTNAME;
-    private String port = DEFAULT_MONGO_DB_PORT;
-    private String databaseName = DEFAULT_MONGO_DB_DATABASE_NAME;
-    private String collectionName = DEFAULT_MONGO_DB_COLLECTION_NAME;
-    private String userName = null;
-    private String password = null;
+	private String hostname = DEFAULT_MONGO_DB_HOSTNAME;
+	private String port = DEFAULT_MONGO_DB_PORT;
+	private String databaseName = DEFAULT_MONGO_DB_DATABASE_NAME;
+	private String collectionName = DEFAULT_MONGO_DB_COLLECTION_NAME;
+	private String userName = null;
+	private String password = null;
 
-    private Mongo mongo = null;
-    private DBCollection collection = null;
+	private Mongo mongo = null;
+	private DBCollection collection = null;
 
-    private boolean initialized = false;
+	private boolean initialized = false;
 
-    /**
-     * @see org.apache.log4j.Appender#requiresLayout()
-     */
-    public boolean requiresLayout() {
-        return (false);
-    }
+	/**
+	 * @see org.apache.log4j.Appender#requiresLayout()
+	 */
+	public boolean requiresLayout() {
+		return (false);
+	}
 
-    /**
-     * @see org.apache.log4j.AppenderSkeleton#activateOptions()
-     */
-    @Override
-    public void activateOptions() {
-        try {
-            // Close previous connections if reactivating
-            if (mongo != null) {
-                close();
-            }
+	/**
+	 * @see org.apache.log4j.AppenderSkeleton#activateOptions()
+	 */
+	@Override
+	public void activateOptions() {
+		try {
+			// Close previous connections if reactivating
+			if (mongo != null) {
+				close();
+			}
 
-            List<ServerAddress> addresses = getServerAddresses(hostname, port);
-        	mongo = getMongo(addresses);
+			List<ServerAddress> addresses = getServerAddresses(hostname, port);
+			mongo = getMongo(addresses);
 
 			DB database = getDatabase(mongo, databaseName);
 
-            if (userName != null && userName.trim().length() > 0) {
-                if (!database.authenticate(userName, password.toCharArray())) {
-                    throw new RuntimeException("Unable to authenticate with MongoDB server.");
-                }
+			if (userName != null && userName.trim().length() > 0) {
+				if (!database.authenticate(userName, password.toCharArray())) {
+					throw new RuntimeException(
+							"Unable to authenticate with MongoDB server.");
+				}
 
-                // Allow password to be GCed
-                password = null;
-            }
+				// Allow password to be GCed
+				password = null;
+			}
 
-            setCollection(database.getCollection(collectionName));
-            initialized = true;
-        } catch (Exception e) {
-            errorHandler.error("Unexpected exception while initialising MongoDbAppender.", e,
-                    ErrorCode.GENERIC_FAILURE);
-        }
-    }
-    
-    /*
-     * This method could be override to provide the DB instance from existing connection.
-     */
-    protected DB getDatabase(Mongo mongo, String databaseName) {
+			setCollection(database.getCollection(collectionName));
+			initialized = true;
+		} catch (Exception e) {
+			errorHandler.error(
+					"Unexpected exception while initialising MongoDbAppender.",
+					e, ErrorCode.GENERIC_FAILURE);
+		}
+	}
+
+	/*
+	 * This method could be override to provide the DB instance from existing
+	 * connection.
+	 */
+	protected DB getDatabase(Mongo mongo, String databaseName) {
 		return mongo.getDB(databaseName);
 	}
 
-    
-    /*
-     * This method could be override to provide the Mongo instance from existing connection.
-     */
+	/*
+	 * This method could be override to provide the Mongo instance from existing
+	 * connection.
+	 */
 	protected Mongo getMongo(List<ServerAddress> addresses) {
 		if (addresses.size() < 2) {
 			return new Mongo(addresses.get(0));
@@ -121,245 +122,253 @@ public class MongoDbAppender extends BsonAppender {
 			return new Mongo(addresses);
 		}
 	}
-    /**
-     * Note: this method is primarily intended for use by the unit tests.
-     * 
-     * @param collection
-     *            The MongoDB collection to use when logging events.
-     */
-    public void setCollection(final DBCollection collection) {
-        // PRECONDITIONS
-        assert collection != null : "collection must not be null.";
 
-        // Body
-        this.collection = collection;
-    }
+	/**
+	 * Note: this method is primarily intended for use by the unit tests.
+	 * 
+	 * @param collection
+	 *            The MongoDB collection to use when logging events.
+	 */
+	public void setCollection(final DBCollection collection) {
+		// PRECONDITIONS
+		assert collection != null : "collection must not be null.";
 
-    /**
-     * @see org.apache.log4j.Appender#close()
-     */
-    public void close() {
-        if (mongo != null) {
-            collection = null;
-            mongo.close();
-        }
-    }
+		// Body
+		this.collection = collection;
+	}
 
-    /**
-     * @return The hostname of the MongoDB server <i>(will not be null, empty or blank)</i>.
-     */
-    public String getHostname() {
-        return (hostname);
-    }
+	/**
+	 * @see org.apache.log4j.Appender#close()
+	 */
+	public void close() {
+		if (mongo != null) {
+			collection = null;
+			mongo.close();
+		}
+	}
 
-    /**
-     * @param hostname
-     *            The MongoDB hostname to set <i>(must not be null, empty or blank)</i>.
-     */
-    public void setHostname(final String hostname) {
-        // PRECONDITIONS
-        assert hostname != null : "hostname must not be null";
-        assert hostname.trim().length() > 0 : "hostname must not be empty or blank";
+	/**
+	 * @return The hostname of the MongoDB server <i>(will not be null, empty or
+	 *         blank)</i>.
+	 */
+	public String getHostname() {
+		return (hostname);
+	}
 
-        // Body
-        this.hostname = hostname;
-    }
+	/**
+	 * @param hostname
+	 *            The MongoDB hostname to set <i>(must not be null, empty or
+	 *            blank)</i>.
+	 */
+	public void setHostname(final String hostname) {
+		// PRECONDITIONS
+		assert hostname != null : "hostname must not be null";
+		assert hostname.trim().length() > 0 : "hostname must not be empty or blank";
 
-    /**
-     * @return The port of the MongoDB server <i>(will be > 0)</i>.
-     */
-    public String getPort() {
-        return (port);
-    }
+		// Body
+		this.hostname = hostname;
+	}
 
-    /**
-     * @param port
-     *            The port to set <i>(must not be null, empty or blank)</i>.
-     */
-    public void setPort(final String port) {
-        // PRECONDITIONS
-        assert port != null : "port must not be null";
-        assert port.trim().length() > 0 : "port must not be empty or blank";
+	/**
+	 * @return The port of the MongoDB server <i>(will be > 0)</i>.
+	 */
+	public String getPort() {
+		return (port);
+	}
 
-        // Body
-        this.port = port;
-    }
+	/**
+	 * @param port
+	 *            The port to set <i>(must not be null, empty or blank)</i>.
+	 */
+	public void setPort(final String port) {
+		// PRECONDITIONS
+		assert port != null : "port must not be null";
+		assert port.trim().length() > 0 : "port must not be empty or blank";
 
-    /**
-     * @return The database used in the MongoDB server <i>(will not be null, empty or blank)</i>.
-     */
-    public String getDatabaseName() {
-        return (databaseName);
-    }
+		// Body
+		this.port = port;
+	}
 
-    /**
-     * @param databaseName
-     *            The database to use in the MongoDB server <i>(must not be null, empty or
-     *            blank)</i>.
-     */
-    public void setDatabaseName(final String databaseName) {
-        // PRECONDITIONS
-        assert databaseName != null : "database must not be null";
-        assert databaseName.trim().length() > 0 : "database must not be empty or blank";
+	/**
+	 * @return The database used in the MongoDB server <i>(will not be null,
+	 *         empty or blank)</i>.
+	 */
+	public String getDatabaseName() {
+		return (databaseName);
+	}
 
-        // Body
-        this.databaseName = databaseName;
-    }
+	/**
+	 * @param databaseName
+	 *            The database to use in the MongoDB server <i>(must not be
+	 *            null, empty or blank)</i>.
+	 */
+	public void setDatabaseName(final String databaseName) {
+		// PRECONDITIONS
+		assert databaseName != null : "database must not be null";
+		assert databaseName.trim().length() > 0 : "database must not be empty or blank";
 
-    /**
-     * @return The collection used within the database in the MongoDB server <i>(will not be null,
-     *         empty or blank)</i>.
-     */
-    public String getCollectionName() {
-        return (collectionName);
-    }
+		// Body
+		this.databaseName = databaseName;
+	}
 
-    /**
-     * @param collectionName
-     *            The collection used within the database in the MongoDB server <i>(must not be
-     *            null, empty or blank)</i>.
-     */
-    public void setCollectionName(final String collectionName) {
-        // PRECONDITIONS
-        assert collectionName != null : "collection must not be null";
-        assert collectionName.trim().length() > 0 : "collection must not be empty or blank";
+	/**
+	 * @return The collection used within the database in the MongoDB server
+	 *         <i>(will not be null, empty or blank)</i>.
+	 */
+	public String getCollectionName() {
+		return (collectionName);
+	}
 
-        // Body
-        this.collectionName = collectionName;
-    }
+	/**
+	 * @param collectionName
+	 *            The collection used within the database in the MongoDB server
+	 *            <i>(must not be null, empty or blank)</i>.
+	 */
+	public void setCollectionName(final String collectionName) {
+		// PRECONDITIONS
+		assert collectionName != null : "collection must not be null";
+		assert collectionName.trim().length() > 0 : "collection must not be empty or blank";
 
-    /**
-     * @return The userName used to authenticate with MongoDB <i>(may be null)</i>.
-     */
-    public String getUserName() {
-        return (userName);
-    }
+		// Body
+		this.collectionName = collectionName;
+	}
 
-    /**
-     * @param userName
-     *            The userName to use when authenticating with MongoDB <i>(may be null)</i>.
-     */
-    public void setUserName(final String userName) {
-        this.userName = userName;
-    }
+	/**
+	 * @return The userName used to authenticate with MongoDB <i>(may be
+	 *         null)</i>.
+	 */
+	public String getUserName() {
+		return (userName);
+	}
 
-    /**
-     * @param password
-     *            The password to use when authenticating with MongoDB <i>(may be null)</i>.
-     */
-    public void setPassword(final String password) {
-        this.password = password;
-    }
+	/**
+	 * @param userName
+	 *            The userName to use when authenticating with MongoDB <i>(may
+	 *            be null)</i>.
+	 */
+	public void setUserName(final String userName) {
+		this.userName = userName;
+	}
 
-    /**
-     * @param bson
-     *            The BSON object to insert into a MongoDB database collection.
-     */
-    @Override
-    public void append(DBObject bson) {
-        if (initialized && bson != null) {
-            try {
-                getCollection().insert(bson);
-            } catch (MongoException e) {
-                errorHandler.error("Failed to insert document to MongoDB", e,
-                        ErrorCode.WRITE_FAILURE);
-            }
-        }
-    }
+	/**
+	 * @param password
+	 *            The password to use when authenticating with MongoDB <i>(may
+	 *            be null)</i>.
+	 */
+	public void setPassword(final String password) {
+		this.password = password;
+	}
 
-    /**
-     * Returns true if appender was successfully initialized. If this method returns false, the
-     * appender should not attempt to log events.
-     * 
-     * @return true if appender was successfully initialized
-     */
-    public boolean isInitialized() {
-        return initialized;
-    }
+	/**
+	 * @param bson
+	 *            The BSON object to insert into a MongoDB database collection.
+	 */
+	@Override
+	public void append(DBObject bson) {
+		if (isInitialized() && bson != null) {
+			try {
+				getCollection().insert(bson);
+			} catch (MongoException e) {
+				errorHandler.error("Failed to insert document to MongoDB", e,
+						ErrorCode.WRITE_FAILURE);
+			}
+		}
+	}
 
-    /**
-     * 
-     * @return The MongoDB collection to which events are logged.
-     */
-    protected DBCollection getCollection() {
-        return (collection);
-    }
+	/**
+	 * Returns true if appender was successfully initialized. If this method
+	 * returns false, the appender should not attempt to log events.
+	 * 
+	 * @return true if appender was successfully initialized
+	 */
+	public boolean isInitialized() {
+		return initialized;
+	}
 
-    /**
-     * Returns a List of ServerAddress objects for each host specified in the hostname property.
-     * Returns an empty list if configuration is detected to be invalid, e.g.:
-     * <ul>
-     * <li>Port property doesn't contain either one port or one port per host</li>
-     * <li>After parsing port property to integers, there isn't either one port or one port per host
-     * </li>
-     * </ul>
-     * 
-     * @param hostname
-     *            Blank space delimited hostnames
-     * @param port
-     *            Blank space delimited ports. Must specify one port for all hosts or a port per
-     *            host.
-     * @return List of ServerAddresses to connect to
-     */
-    private List<ServerAddress> getServerAddresses(String hostname, String port) {
-        List<ServerAddress> addresses = new ArrayList<ServerAddress>();
+	/**
+	 * 
+	 * @return The MongoDB collection to which events are logged.
+	 */
+	protected DBCollection getCollection() {
+		return (collection);
+	}
 
-        String[] hosts = hostname.split(" ");
-        String[] ports = port.split(" ");
+	/**
+	 * Returns a List of ServerAddress objects for each host specified in the
+	 * hostname property. Returns an empty list if configuration is detected to
+	 * be invalid, e.g.:
+	 * <ul>
+	 * <li>Port property doesn't contain either one port or one port per host</li>
+	 * <li>After parsing port property to integers, there isn't either one port
+	 * or one port per host</li>
+	 * </ul>
+	 * 
+	 * @param hostname
+	 *            Blank space delimited hostnames
+	 * @param port
+	 *            Blank space delimited ports. Must specify one port for all
+	 *            hosts or a port per host.
+	 * @return List of ServerAddresses to connect to
+	 */
+	private List<ServerAddress> getServerAddresses(String hostname, String port) {
+		List<ServerAddress> addresses = new ArrayList<ServerAddress>();
 
-        if (ports.length != 1 && ports.length != hosts.length) {
-            errorHandler.error(
-                    "MongoDB appender port property must contain one port or a port per host",
-                    null, ErrorCode.ADDRESS_PARSE_FAILURE);
-        } else {
-            List<Integer> portNums = getPortNums(ports);
-            // Validate number of ports again after parsing
-            if (portNums.size() != 1 && portNums.size() != hosts.length) {
-                errorHandler
-                        .error("MongoDB appender port property must contain one port or a valid port per host",
-                                null, ErrorCode.ADDRESS_PARSE_FAILURE);
-            } else {
-                boolean onePort = (portNums.size() == 1);
+		String[] hosts = hostname.split(" ");
+		String[] ports = port.split(" ");
 
-                int i = 0;
-                for (String host : hosts) {
-                    int portNum = (onePort) ? portNums.get(0) : portNums.get(i);
-                    try {
-                        addresses.add(new ServerAddress(host.trim(), portNum));
-                    } catch (UnknownHostException e) {
-                        errorHandler.error(
-                                "MongoDB appender hostname property contains unknown host", e,
-                                ErrorCode.ADDRESS_PARSE_FAILURE);
-                    }
-                    i++;
-                }
-            }
-        }
-        return addresses;
-    }
+		if (ports.length != 1 && ports.length != hosts.length) {
+			errorHandler
+					.error("MongoDB appender port property must contain one port or a port per host",
+							null, ErrorCode.ADDRESS_PARSE_FAILURE);
+		} else {
+			List<Integer> portNums = getPortNums(ports);
+			// Validate number of ports again after parsing
+			if (portNums.size() != 1 && portNums.size() != hosts.length) {
+				errorHandler
+						.error("MongoDB appender port property must contain one port or a valid port per host",
+								null, ErrorCode.ADDRESS_PARSE_FAILURE);
+			} else {
+				boolean onePort = (portNums.size() == 1);
 
-    private List<Integer> getPortNums(String[] ports) {
-        List<Integer> portNums = new ArrayList<Integer>();
+				int i = 0;
+				for (String host : hosts) {
+					int portNum = (onePort) ? portNums.get(0) : portNums.get(i);
+					try {
+						addresses.add(new ServerAddress(host.trim(), portNum));
+					} catch (UnknownHostException e) {
+						errorHandler
+								.error("MongoDB appender hostname property contains unknown host",
+										e, ErrorCode.ADDRESS_PARSE_FAILURE);
+					}
+					i++;
+				}
+			}
+		}
+		return addresses;
+	}
 
-        for (String port : ports) {
-            try {
-                Integer portNum = Integer.valueOf(port.trim());
-                if (portNum < 0) {
-                    errorHandler.error(
-                            "MongoDB appender port property can't contain a negative integer",
-                            null, ErrorCode.ADDRESS_PARSE_FAILURE);
-                } else {
-                    portNums.add(portNum);
-                }
-            } catch (NumberFormatException e) {
-                errorHandler.error(
-                        "MongoDB appender can't parse a port property value into an integer", e,
-                        ErrorCode.ADDRESS_PARSE_FAILURE);
-            }
+	private List<Integer> getPortNums(String[] ports) {
+		List<Integer> portNums = new ArrayList<Integer>();
 
-        }
+		for (String port : ports) {
+			try {
+				Integer portNum = Integer.valueOf(port.trim());
+				if (portNum < 0) {
+					errorHandler
+							.error("MongoDB appender port property can't contain a negative integer",
+									null, ErrorCode.ADDRESS_PARSE_FAILURE);
+				} else {
+					portNums.add(portNum);
+				}
+			} catch (NumberFormatException e) {
+				errorHandler
+						.error("MongoDB appender can't parse a port property value into an integer",
+								e, ErrorCode.ADDRESS_PARSE_FAILURE);
+			}
 
-        return portNums;
-    }
+		}
+
+		return portNums;
+	}
 
 }


### PR DESCRIPTION
E.g. If the user is using Cloudfoundry, and have the access to
MongoDBFactory object, we should be able to eliminate the need to get
the new Mongo instance, and reinitializing it, as it would require the
username and password credential which are not available through code.
